### PR TITLE
Fix MongoDB PHP Extension Version

### DIFF
--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y php8.1-cli php8.1-dev \
        php8.1-pgsql php8.1-sqlite3 php8.1-gd \
-       php8.1-curl php8.4-mongodb \
+       php8.1-curl php8.1-mongodb \
        php8.1-imap php8.1-mysql php8.1-mbstring \
        php8.1-xml php8.1-zip php8.1-bcmath php8.1-soap \
        php8.1-intl php8.1-readline \

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y php8.2-cli php8.2-dev \
        php8.2-pgsql php8.2-sqlite3 php8.2-gd \
-       php8.2-curl php8.4-mongodb \
+       php8.2-curl php8.2-mongodb \
        php8.2-imap php8.2-mysql php8.2-mbstring \
        php8.2-xml php8.2-zip php8.2-bcmath php8.2-soap \
        php8.2-intl php8.2-readline \

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y php8.3-cli php8.3-dev \
        php8.3-pgsql php8.3-sqlite3 php8.3-gd \
-       php8.3-curl php8.4-mongodb \
+       php8.3-curl php8.3-mongodb \
        php8.3-imap php8.3-mysql php8.3-mbstring \
        php8.3-xml php8.3-zip php8.3-bcmath php8.3-soap \
        php8.3-intl php8.3-readline \


### PR DESCRIPTION
# Changes

Corrected the MongoDB PHP extension version in Dockerfiles for PHP 8.1, 8.2, and 8.3 runtimes
Changed from php8.4-mongodb to the correct version matching each PHP runtime (php8.1-mongodb, php8.2-mongodb, and php8.3-mongodb respectively)

# Why

The previous configuration referenced the MongoDB extension with an incorrect PHP version number. This fix ensures that each runtime references the MongoDB extension package that matches its corresponding PHP version.

# Affected Files

- runtimes/8.1/Dockerfile
- runtimes/8.2/Dockerfile
- runtimes/8.3/Dockerfile